### PR TITLE
Update settings.xml

### DIFF
--- a/game.libretro.4do/resources/settings.xml
+++ b/game.libretro.4do/resources/settings.xml
@@ -2,7 +2,7 @@
 <settings>
 	<category label="30000">
 		<setting label="30001" type="select" id="4do_active_devices" values="1|2|3|4|5|6|7|8|0" default="1"/>
-		<setting label="30002" type="select" id="4do_bios" values="None Found" default="None Found"/>
+		<setting label="30002" type="select" id="4do_bios" values="Panasonic FZ-1|Panasonic FZ-10" default="Panasonic FZ-1"/>
 		<setting label="30003" type="select" id="4do_cpu_overclock" values="1.0x (12.50Mhz)|1.1x (13.75Mhz)|1.2x (15.00Mhz)|1.5x (18.75Mhz)|1.6x (20.00Mhz)|1.8x (22.50Mhz)|2.0x (25.00Mhz)" default="1.0x (12.50Mhz)"/>
 		<setting label="30004" type="select" id="4do_dsp_threaded" values="disabled|enabled" default="disabled"/>
 		<setting label="30005" type="select" id="4do_font" values="disabled" default="disabled"/>


### PR DESCRIPTION
previous 4do_bios setting would prevent the core from starting.  "None found" is not a valid default