### PR TITLE
Update settings.xml again

### DIFF
--- a/game.libretro.4do/resources/settings.xml
+++ b/game.libretro.4do/resources/settings.xml
@@ -2,7 +2,7 @@
 <settings>
 	<category label="30000">
 		<setting label="30001" type="select" id="4do_active_devices" values="1|2|3|4|5|6|7|8|0" default="1"/>
-		<setting label="30002" type="select" id="4do_bios" values="Panasonic FZ-1|Panasonic FZ-10" default="Panasonic FZ-1"/>
+		<setting label="30002" type="select" id="4do_bios" values="Panasonic FZ-1|Panasonic FZ-10|Panasonic FZ-10 [RSA Patch]|Panasonic FZ-10E [Anvil]|Panasonic FZ-10E [Anvil RSA Patch]|Goldstar GDO-101M|Sanyo Try IMP-21J|3DO Arcade - SAOT|FZ-1 Kanji ROM|FZ-10JA Kanji ROM" default="Panasonic FZ-1"/>
 		<setting label="30003" type="select" id="4do_cpu_overclock" values="1.0x (12.50Mhz)|1.1x (13.75Mhz)|1.2x (15.00Mhz)|1.5x (18.75Mhz)|1.6x (20.00Mhz)|1.8x (22.50Mhz)|2.0x (25.00Mhz)" default="1.0x (12.50Mhz)"/>
 		<setting label="30004" type="select" id="4do_dsp_threaded" values="disabled|enabled" default="disabled"/>
 		<setting label="30005" type="select" id="4do_font" values="disabled" default="disabled"/>


### PR DESCRIPTION
The bios options weren't well documented (which is probably why the setting was incorrect in the first place).  Updating again to add the other options.   All the options I found are here:  https://github.com/libretro/4do-libretro/blob/master/libfreedo/freedo_bios.c