### PR TITLE
Fix input and add update topology.xml

### DIFF
--- a/game.libretro.opera/resources/buttonmap.xml
+++ b/game.libretro.opera/resources/buttonmap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<buttonmap>
+<buttonmap version="2">
 	<controller id="game.controller.3do" type="RETRO_DEVICE_JOYPAD">
 		<feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
 		<feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>

--- a/game.libretro.opera/resources/topology.xml
+++ b/game.libretro.opera/resources/topology.xml
@@ -11,7 +11,15 @@
                   <port id="1">
                     <accepts controller="game.controller.3do">
                       <port id="1">
-                        <accepts controller="game.controller.3do"/>
+                        <accepts controller="game.controller.3do">
+                          <port id="1">
+                            <accepts controller="game.controller.3do">
+                              <port id="1">
+                                <accepts controller="game.controller.3do"/>
+                              </port>
+                            </accepts>
+                          </port>
+                        </accepts>
                       </port>
                     </accepts>
                   </port>


### PR DESCRIPTION
## Description

Fixes broken input in Opera. Also increases the number of controllers from 6 to 8, per the source: https://github.com/libretro/opera-libretro/blob/67a29e60a4d194b675c9272b21b61eaa022f3ba3/lr_input.h#L8

```
#define LR_INPUT_MAX_DEVICES 8
```

TODO: Add support for additional controllers beyond the gamepad:

```
static const struct retro_controller_description port[] =
  {
   { "3DO Joypad",        RETRO_DEVICE_JOYPAD },
   { "3DO Flightstick",   RETRO_DEVICE_FLIGHTSTICK },
   { "3DO Mouse",         RETRO_DEVICE_MOUSE  },
   { "3DO Lightgun",      RETRO_DEVICE_LIGHTGUN },
   { "Arcade Lightgun",   RETRO_DEVICE_ARCADE_LIGHTGUN },
   { "Orbatak Trackball", RETRO_DEVICE_ORBATAK_TRACKBALL },
  };

static const struct retro_controller_info ports[LR_INPUT_MAX_DEVICES+1] =
  {
   {port, 6},
   {port, 6},
   {port, 6},
   {port, 6},
   {port, 6},
   {port, 6},
   {port, 6},
   {port, 6},
   {NULL, 0}
  };
```

```
#define RETRO_DEVICE_FLIGHTSTICK RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD,0)
#define RETRO_DEVICE_ARCADE_LIGHTGUN RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_LIGHTGUN,0)
#define RETRO_DEVICE_ORBATAK_TRACKBALL RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD,1)
```

## How has this been tested?

Tested as part of https://github.com/xbmc/xbmc/pull/26194

<img width="1275" alt="Screenshot 2024-12-30 at 8 22 02 AM" src="https://github.com/user-attachments/assets/433ef6c3-5456-46e8-84fe-e1a0978ab517" />